### PR TITLE
get tab info from callback

### DIFF
--- a/background.js
+++ b/background.js
@@ -52,15 +52,13 @@ async function getCurrentTab() {
 }
 
 
-chrome.contextMenus.onClicked.addListener(item => {
-    getCurrentTab().then(tab => {
-        const tabId = tab.id
-        
-        chrome.scripting.executeScript({
-            target: { tabId: tabId },
-            func: getSelectedText,
-        }, (selection) => {
-            inspect_code(selection[0].result);
-        });
-    })
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+    const tabId = tab.id
+    
+    chrome.scripting.executeScript({
+        target: { tabId: tabId },
+        func: getSelectedText,
+    }, (selection) => {
+        inspect_code(selection[0].result);
+    });
 });


### PR DESCRIPTION
- tabに関する情報をcontext menuクリック時のcallbackから受け取るようにすることで、別のタブにフォーカスが当たっている場合でもうまく動作するようになりました。

https://github.com/ryoma310/py-spice/blob/4ed7cc21926f0ba069ec5b4e7bdf7c341caefe2f/background.js#L55-L64